### PR TITLE
Parse spectra and output ascii files

### DIFF
--- a/neutronimaging/detector_correction.py
+++ b/neutronimaging/detector_correction.py
@@ -60,6 +60,14 @@ def merge_meta_data(
     return _df
 
 
+def skipping_meta_data(meta: pd.DataFrame) -> pd.DataFrame:
+    """Skips first and last or each run in metadata"""
+    _by_shutter = meta.groupby(['shutter_index'])
+    # groupby returns (group_num, dataframe), thus the [1] first
+    _with_skips = [item[1][1:-1] for item in _by_shutter]
+    return pd.concat(_with_skips)
+
+
 def load_images(raw_imamge_dir: str) -> Type[Normalization]:
     """Loading all Images into memory"""
     import glob

--- a/scripts/mcp_detector_correction.py
+++ b/scripts/mcp_detector_correction.py
@@ -16,6 +16,9 @@ Options:
 """
 
 import glob
+import os
+import pandas as pd
+import shutil
 from docopt import docopt
 from pathlib import Path
 from neutronimaging.detector_correction import (
@@ -78,3 +81,21 @@ if __name__ == "__main__":
     print(f"Writing data to {output_dir}")
     o_norm.data["sample"]["data"] = img_corrected
     o_norm.export(folder=output_dir, data_type="sample")
+    out_shutter_count = os.path.join(output_dir,
+                                     os.path.basename(shutter_count_file))
+    out_shutter_time = os.path.join(output_dir,
+                                    os.path.basename(shutter_time_file))
+    out_spectra_file = os.path.join(output_dir,
+                                    os.path.basename(spectra_file))
+    shutil.copyfile(shutter_count_file, out_shutter_count)
+    shutil.copyfile(shutter_time_file, out_shutter_time)
+    # handle proper spectra parsing
+    if skip_first_last_img:
+        pd.concat(
+            [run[1][1:-1] for run in df_meta.groupby(['shutter_index'])]
+        ).to_csv(out_spectra_file,
+                 columns=['shutter_time', 'counts'],
+                 index=False,
+                 index_label=False)
+    else:
+        shutil.copyfile(spectra_file, out_spectra_file)

--- a/scripts/mcp_detector_correction.py
+++ b/scripts/mcp_detector_correction.py
@@ -17,7 +17,6 @@ Options:
 
 import glob
 import os
-import pandas as pd
 import shutil
 from docopt import docopt
 from pathlib import Path
@@ -28,6 +27,7 @@ from neutronimaging.detector_correction import (
     read_shutter_time,
     read_spectra,
     merge_meta_data,
+    skipping_meta_data,
 )
 
 
@@ -91,11 +91,11 @@ if __name__ == "__main__":
     shutil.copyfile(shutter_time_file, out_shutter_time)
     # handle proper spectra parsing
     if skip_first_last_img:
-        pd.concat(
-            [run[1][1:-1] for run in df_meta.groupby(['shutter_index'])]
-        ).to_csv(out_spectra_file,
-                 columns=['shutter_time', 'counts'],
-                 index=False,
-                 index_label=False)
+        skipping_meta_data(df_meta).to_csv(
+            out_spectra_file,
+            columns=['shutter_time', 'counts'],
+            index=False,
+            index_label=False
+        )
     else:
         shutil.copyfile(spectra_file, out_spectra_file)

--- a/tests/test_detector_correction.py
+++ b/tests/test_detector_correction.py
@@ -35,7 +35,8 @@ def test_skipping_meta_data():
     test_output = pd.DataFrame(
         [['c', 3]]
         + [['d', 4]]*2,
-        columns=['letter', 'shutter_index']
+        columns=['letter', 'shutter_index'],
+        index=[4, 7, 8]
     )
     skipped = skipping_meta_data(test_input)
     assert (skipped == test_output).all(None)

--- a/tests/test_detector_correction.py
+++ b/tests/test_detector_correction.py
@@ -30,12 +30,12 @@ def test_skipping_meta_data():
         + [['b', 2]]*2
         + [['c', 3]]*3
         + [['d', 4]]*4,
-        columns=['letter', 'num']
+        columns=['letter', 'shutter_index']
     )
     test_output = pd.DataFrame(
         [['c', 3]]
         + [['d', 4]]*2,
-        columns=['letter', 'num']
+        columns=['letter', 'shutter_index']
     )
     skipped = skipping_meta_data(test_input)
     assert (skipped == test_output).all(None)

--- a/tests/test_detector_correction.py
+++ b/tests/test_detector_correction.py
@@ -6,6 +6,7 @@ NetronImaging
 """
 import os
 import pytest
+import pandas as pd
 import numpy as np
 from neutronimaging.detector_correction import (
     calc_pixel_occupancy_probability,
@@ -15,11 +16,29 @@ from neutronimaging.detector_correction import (
     read_shutter_time,
     read_spectra,
     merge_meta_data,
+    skipping_meta_data,
 )
 
 
 _file_root = os.path.dirname(os.path.abspath(__file__))
 test_data_dir = os.path.join(_file_root, "../data")
+
+
+def test_skipping_meta_data():
+    test_input = pd.DataFrame(
+        [['a', 1]]
+        + [['b', 2]]*2
+        + [['c', 3]]*3
+        + [['d', 4]]*4,
+        columns=['letter', 'num']
+    )
+    test_output = pd.DataFrame(
+        [['c', 3]]
+        + [['d', 4]]*2,
+        columns=['letter', 'num']
+    )
+    skipped = skipping_meta_data(test_input)
+    assert (skipped == test_output).all(None)
 
 
 def test_calc_pixel_occupancy_probability():


### PR DESCRIPTION
The ascii files in the input are now appropriately transferred to the output at the end of processing. The shutter files are directly copied regardless of skipimg. The spectra file respects skipimg and will strip the first and last of each run if the flag is present.