### PR TITLE
Copy `_SummedImg.fits` from raw folder to corrected folder when running the mcp_correction code

### DIFF
--- a/scripts/mcp_detector_correction.py
+++ b/scripts/mcp_detector_correction.py
@@ -51,6 +51,7 @@ if __name__ == "__main__":
     shutter_count_file = glob.glob(input_dir + "/*_ShutterCount.txt")[0]
     shutter_time_file = glob.glob(input_dir + "/*_ShutterTimes.txt")[0]
     spectra_file = glob.glob(input_dir + "/*_Spectra.txt")[0]
+    summed_file = glob.glob(input_dir + "/*_SummedImg.fits")[0]
 
     # validation
     print("Validating input arguments")
@@ -59,6 +60,7 @@ if __name__ == "__main__":
     assert Path(shutter_count_file).exists()
     assert Path(shutter_time_file).exists()
     assert Path(spectra_file).exists()
+    assert Path(summed_file).exists()
 
     # process metadata
     print("Processing metadata")
@@ -95,8 +97,11 @@ if __name__ == "__main__":
                                     os.path.basename(shutter_time_file))
     out_spectra_file = os.path.join(output_dir,
                                     os.path.basename(spectra_file))
+    out_summed_file = os.path.join(output_dir, 
+                                    os.path.basename(summed_file))                                
     shutil.copyfile(shutter_count_file, out_shutter_count)
     shutil.copyfile(shutter_time_file, out_shutter_time)
+    shutil.copyfile(summed_file, out_summed_file)
     # handle proper spectra parsing
     if skip_first_last_img:
         skipping_meta_data(df_meta).to_csv(


### PR DESCRIPTION
test can be performed on the following data
/SNS/SNAP/IPTS-30023/images/mcp/scan/Run_56173

procedure to test it on the analysis machine
```
conda activate /opt/anaconda/envs/ImagingReduction
```
and run the command

```
mcp_detector_correction.py --skipimg /SNS/SNAP/IPTS-30023/images/mcp/scan/Run_56173/ ~/tmp/
```
and make sure the file that ends with _SummedImg.fits is now in the output folder