### PR TITLE
fix: update CI to modern actions and Python versions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.10", "3.11", "3.12"]
 
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
         


### PR DESCRIPTION
## Summary
- Update `actions/checkout` v2 → v4 and `actions/setup-python` v2 → v5
- Update Python matrix from 3.6/3.7/3.8 to 3.10/3.11/3.12
- Python 3.6 (EOL Dec 2021) and 3.7 (EOL Jun 2023) are no longer available on GitHub runners

## Test plan
- [ ] CI passes with the new Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)