### PR TITLE
test: pin load/export/CLI contracts ahead of the NeuNorm removal

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Runtime dependencies for neutronimaging
 
+astropy  # FITS reading in the contract tests; explicit rather than transitive via NeuNorm
 docopt
 h5py  # used by NeuNorm 1.x loader but not declared as its dependency
 ipympl

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,92 @@
+"""Shared fixtures for NeutronImagingScripts tests."""
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="session")
+def repo_root() -> Path:
+    return REPO_ROOT
+
+
+@pytest.fixture(scope="session")
+def data_dir() -> Path:
+    return REPO_ROOT / "data"
+
+
+def _write_fits_int16(path: Path, image: np.ndarray) -> None:
+    """Write a big-endian int16 FITS file, matching the shipped MCP data."""
+    hdu = fits.PrimaryHDU(image.astype(">i2"))
+    fits.HDUList([hdu]).writeto(str(path))
+
+
+@pytest.fixture
+def synthetic_mcp_dataset(tmp_path):
+    """A miniature but complete MCP dataset for CLI/export contract tests.
+
+    3 shutter windows x 4 frames of constant-valued 32x32 big-endian int16
+    images, with matching ShutterCount/ShutterTimes/Spectra TSV files and a
+    _SummedImg.fits, mirroring the layout the beamline autoreduction feeds
+    to mcp_detector_correction.
+    """
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    prefix = "OB_synth_005"
+    n_groups, frames_per_group = 3, 4
+    n_frames = n_groups * frames_per_group
+    shape = (32, 32)
+
+    # constant-valued frames, value = 10 + frame index, so every frame is
+    # distinguishable and occupancy stays far from the 1-pole
+    frame_values = [10 + k for k in range(n_frames)]
+    for k, value in enumerate(frame_values):
+        _write_fits_int16(input_dir / f"{prefix}_{k:05d}.fits", np.full(shape, value, dtype=np.int16))
+    # excluded from loading, but required by the CLI's input validation
+    _write_fits_int16(input_dir / f"{prefix}_SummedImg.fits", np.full(shape, 1, dtype=np.int16))
+
+    # ShutterCount.txt: index\tcounts; trailing zero-count row is filtered out
+    counts = [100000, 80000, 60000]
+    lines = [f"{i}\t{c}" for i, c in enumerate(counts)] + ["3\t0"]
+    (input_dir / f"{prefix}_ShutterCount.txt").write_text("\n".join(lines) + "\n")
+
+    # ShutterTimes.txt: index\tstart_delta\tend_delta; read_shutter_time
+    # cumulative-sums the flattened deltas, so deltas of (0.001, 0.002) per
+    # row yield absolute windows [0.001,0.003], [0.004,0.006], [0.007,0.009]
+    lines = [f"{i}\t0.001\t0.002" for i in range(n_groups)] + ["3\t0\t0"]
+    (input_dir / f"{prefix}_ShutterTimes.txt").write_text("\n".join(lines) + "\n")
+
+    # Spectra.txt: time\tcounts, headerless TSV; 4 times inside each window
+    window_starts = [0.001, 0.004, 0.007]
+    spectra_times = [start + offset for start in window_starts for offset in (0.0002, 0.0008, 0.0014, 0.0019)]
+    lines = [
+        f"{t:.6f}\t{value * shape[0] * shape[1]}" for t, value in zip(spectra_times, frame_values, strict=True)
+    ]
+    (input_dir / f"{prefix}_Spectra.txt").write_text("\n".join(lines) + "\n")
+
+    return {
+        "input_dir": input_dir,
+        "output_dir": output_dir,
+        "prefix": prefix,
+        "n_groups": n_groups,
+        "frames_per_group": frames_per_group,
+        "n_frames": n_frames,
+        "shape": shape,
+        "frame_values": frame_values,
+    }
+
+
+@pytest.fixture
+def script_path():
+    def _script(name: str) -> str:
+        return os.fspath(REPO_ROOT / "scripts" / name)
+
+    return _script

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -1,0 +1,180 @@
+"""CLI and export contract tests for the scripts/ entry points.
+
+These pin the on-disk output contract of mcp_detector_correction (filenames,
+dtype, full-array values, sidecar copies) ahead of the NeuNorm removal —
+previously the export path had zero test coverage. The scripts have no
+main() function, so they are exercised via subprocess, which also pins the
+autoreduction-facing command-line interface itself.
+"""
+
+import filecmp
+import json
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from neutronimaging.detector_correction import (
+    correct_images,
+    load_images,
+    merge_meta_data,
+    read_shutter_count,
+    read_shutter_time,
+    read_spectra,
+    skipping_meta_data,
+)
+
+
+def _run_cli(script, *args):
+    return subprocess.run(
+        [sys.executable, script, *map(str, args)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+def _read_tiff(path) -> np.ndarray:
+    with Image.open(path) as img:
+        return np.array(img)
+
+
+def _expected_corrected(input_dir, skip=False) -> np.ndarray:
+    prefix_glob = sorted(input_dir.glob("*_ShutterCount.txt"))[0]
+    stem = prefix_glob.name.replace("_ShutterCount.txt", "")
+    meta = merge_meta_data(
+        read_shutter_count(str(input_dir / f"{stem}_ShutterCount.txt")),
+        read_shutter_time(str(input_dir / f"{stem}_ShutterTimes.txt")),
+        read_spectra(str(input_dir / f"{stem}_Spectra.txt")),
+    )
+    o_norm = load_images(str(input_dir))
+    return correct_images(o_norm, meta, skip_first_and_last=skip)
+
+
+class TestMcpDetectorCorrectionCli:
+    def test_end_to_end_export_contract(self, synthetic_mcp_dataset, script_path):
+        """Full-array, full-naming export contract for the no-skip path."""
+        ds = synthetic_mcp_dataset
+        result = _run_cli(script_path("mcp_detector_correction.py"), ds["input_dir"], ds["output_dir"])
+        assert result.returncode == 0, result.stderr
+
+        # one float32 TIFF per source frame, named after the source stem
+        tiffs = sorted(ds["output_dir"].glob("*.tif"))
+        expected_names = [f"{ds['prefix']}_{k:05d}.tif" for k in range(ds["n_frames"])]
+        assert [t.name for t in tiffs] == expected_names
+
+        expected = _expected_corrected(ds["input_dir"]).astype(np.float32)
+        for k, tiff in enumerate(tiffs):
+            on_disk = _read_tiff(tiff)
+            assert on_disk.dtype == np.float32
+            np.testing.assert_array_equal(on_disk, expected[k])
+
+        # sidecar metadata files are copied verbatim in the no-skip path
+        for suffix in ("_ShutterCount.txt", "_ShutterTimes.txt", "_Spectra.txt", "_SummedImg.fits"):
+            name = f"{ds['prefix']}{suffix}"
+            assert filecmp.cmp(ds["input_dir"] / name, ds["output_dir"] / name, shallow=False), (
+                f"{name} was not copied verbatim"
+            )
+
+    def test_skipimg_frame_count_and_spectra_emitted(self, synthetic_mcp_dataset, script_path):
+        """--skipimg drops the first and last frame of each shutter group."""
+        ds = synthetic_mcp_dataset
+        result = _run_cli(
+            script_path("mcp_detector_correction.py"), "--skipimg", ds["input_dir"], ds["output_dir"]
+        )
+        assert result.returncode == 0, result.stderr
+
+        tiffs = sorted(ds["output_dir"].glob("*.tif"))
+        assert len(tiffs) == ds["n_groups"] * (ds["frames_per_group"] - 2)
+        assert (ds["output_dir"] / f"{ds['prefix']}_Spectra.txt").exists()
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="NeuNorm 1.x export zip-truncates the full filename list against the "
+        "skip-reduced stack, mislabeling kept frames with the first N source names; "
+        "the loader-replacement PR fixes this to use the true kept source names "
+        "(remove this marker there).",
+    )
+    def test_skipimg_exports_true_source_names(self, synthetic_mcp_dataset, script_path):
+        """Kept frames must be written under their true source stems."""
+        ds = synthetic_mcp_dataset
+        result = _run_cli(
+            script_path("mcp_detector_correction.py"), "--skipimg", ds["input_dir"], ds["output_dir"]
+        )
+        assert result.returncode == 0, result.stderr
+
+        kept = [
+            g * ds["frames_per_group"] + i
+            for g in range(ds["n_groups"])
+            for i in range(1, ds["frames_per_group"] - 1)
+        ]
+        expected_names = {f"{ds['prefix']}_{k:05d}.tif" for k in kept}
+        actual_names = {t.name for t in ds["output_dir"].glob("*.tif")}
+        assert actual_names == expected_names
+
+    def test_skip_selector_consistency(self, synthetic_mcp_dataset):
+        """correct_images inlines its own skip logic; pin that it selects the
+        same rows as skipping_meta_data, which the CLI uses for the spectra."""
+        ds = synthetic_mcp_dataset
+        input_dir = ds["input_dir"]
+        meta = merge_meta_data(
+            read_shutter_count(str(input_dir / f"{ds['prefix']}_ShutterCount.txt")),
+            read_shutter_time(str(input_dir / f"{ds['prefix']}_ShutterTimes.txt")),
+            read_spectra(str(input_dir / f"{ds['prefix']}_Spectra.txt")),
+        )
+        o_norm = load_images(str(input_dir))
+
+        full = correct_images(o_norm, meta)
+        skipped = correct_images(o_norm, meta, skip_first_and_last=True)
+        kept_run_nums = skipping_meta_data(meta)["run_num"].values
+
+        assert skipped.shape[0] == len(kept_run_nums)
+        np.testing.assert_array_equal(skipped, full[kept_run_nums])
+
+
+GENERATE_CONFIG_XFAIL = pytest.mark.xfail(
+    strict=True,
+    reason="generate_config_CG1D's output= path json.dumps numpy int64 scalars and "
+    "crashes (TypeError: Object of type int64 is not JSON serializable), so the CLI "
+    "is broken end-to-end on modern numpy/pandas; the existing test_preprocess smoke "
+    "never exercises output=. Fix lands in the correctness PR (remove this marker there).",
+)
+
+
+class TestGenerateConfigCli:
+    @GENERATE_CONFIG_XFAIL
+    def test_single_image_dir(self, data_dir, tmp_path, script_path):
+        out = tmp_path / "config.json"
+        result = _run_cli(
+            script_path("generate_config.py"),
+            data_dir / "IPTS-20267/raw/radiographs",
+            data_dir / "IPTS-20267/raw/ob",
+            data_dir / "IPTS-20267/raw/df",
+            out,
+        )
+        assert result.returncode == 0, result.stderr
+        assert out.exists()
+        json.loads(out.read_text())  # valid JSON
+
+    @GENERATE_CONFIG_XFAIL
+    def test_comma_separated_image_dirs_and_tolerance(self, data_dir, tmp_path, script_path):
+        out = tmp_path / "config.json"
+        imgdirs = ",".join(
+            [
+                str(data_dir / "IPTS-20267/raw/radiographs"),
+                str(data_dir / "IPTS-20267/raw/alignment_calibration"),
+            ]
+        )
+        result = _run_cli(
+            script_path("generate_config.py"),
+            imgdirs,
+            data_dir / "IPTS-20267/raw/ob",
+            data_dir / "IPTS-20267/raw/df",
+            out,
+            "--tolerance=2.0",
+        )
+        assert result.returncode == 0, result.stderr
+        assert out.exists()
+        json.loads(out.read_text())

--- a/tests/test_load_contract.py
+++ b/tests/test_load_contract.py
@@ -1,0 +1,128 @@
+"""Contract tests pinning load_images() ahead of the NeuNorm removal.
+
+The existing npz regression tests assert per-frame *means*, which are
+invariant under transpose/flip/rotation/pixel permutation; these tests pin
+the parts a loader replacement could silently break: pixel values against
+an independent reader, dtype, ordering, exclusions, truncation semantics,
+and image orientation.
+"""
+
+import shutil
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from neutronimaging.detector_correction import load_images
+
+
+def _write_fits_int16(path, image: np.ndarray) -> None:
+    """Write a big-endian int16 FITS file, matching the shipped MCP data."""
+    hdu = fits.PrimaryHDU(image.astype(">i2"))
+    fits.HDUList([hdu]).writeto(str(path))
+
+
+def _stack(o_norm) -> np.ndarray:
+    return np.array(o_norm.data["sample"]["data"])
+
+
+def _astropy_read_float32(path) -> np.ndarray:
+    with fits.open(str(path), ignore_missing_end=True) as hdulist:
+        return np.squeeze(np.asarray(hdulist[0].data, dtype=np.float32))
+
+
+class TestShippedDataContract:
+    """Pin the load contract on the full shipped 916-frame OB stack."""
+
+    @pytest.fixture(scope="class")
+    def full_stack(self, data_dir):
+        return _stack(load_images(str(data_dir)))
+
+    def test_shape_and_dtype(self, full_stack):
+        assert full_stack.shape == (916, 512, 512)
+        assert full_stack.dtype == np.float32
+
+    def test_sampled_pixel_goldens(self, full_stack):
+        """Spot values at off-center coordinates fail loudly on any spatial
+        transform, unlike the mean-profile regressions."""
+        assert full_stack[100][37, 411] == 69.0
+        assert full_stack[100][250, 17] == 194.0
+        assert full_stack[500][37, 411] == 55.0
+        assert full_stack[500][250, 17] == 138.0
+        assert full_stack[915][37, 411] == 43.0
+        assert full_stack[915][250, 17] == 84.0
+
+    def test_frame0_total_counts(self, full_stack):
+        """Frame 0's pixel sum equals the first Spectra counts entry."""
+        assert float(full_stack[0].sum()) == 162259.0
+
+
+class TestLoadSemantics:
+    def test_values_match_independent_reader(self, data_dir, tmp_path):
+        """Pixel-value parity against a direct astropy read.
+
+        The shipped frames are int16 far below the auto-gamma-filter
+        threshold (max value 1514 vs 32762), so loaded values must equal
+        the raw file contents exactly.
+        """
+        names = ["OB_1_005_00000.fits", "OB_1_005_00100.fits", "OB_1_005_00500.fits"]
+        for name in names:
+            shutil.copy(data_dir / name, tmp_path / name)
+
+        loaded = _stack(load_images(str(tmp_path)))
+        assert loaded.shape[0] == len(names)
+        for frame, name in zip(loaded, names, strict=True):
+            np.testing.assert_array_equal(frame, _astropy_read_float32(tmp_path / name))
+
+    def test_sorted_order_and_summedimg_excluded(self, data_dir, tmp_path):
+        """Frames load in sorted-filename order; *_SummedImg* is excluded."""
+        # copy in deliberately unsorted creation order
+        for name in ["OB_1_005_00500.fits", "OB_1_005_00000.fits", "OB_1_005_00100.fits"]:
+            shutil.copy(data_dir / name, tmp_path / name)
+        shutil.copy(data_dir / "OB_1_005_00000.fits", tmp_path / "OB_1_005_SummedImg.fits")
+
+        loaded = _stack(load_images(str(tmp_path)))
+        assert loaded.shape[0] == 3  # SummedImg excluded
+        np.testing.assert_array_equal(loaded[0], _astropy_read_float32(tmp_path / "OB_1_005_00000.fits"))
+        np.testing.assert_array_equal(loaded[2], _astropy_read_float32(tmp_path / "OB_1_005_00500.fits"))
+
+    def test_orientation_canary(self, tmp_path):
+        """A corner marker must land exactly where it was written.
+
+        The shipped frames carry no orientation-asymmetric ground truth,
+        so a vertical flip (the classic FITS origin bug) would be invisible
+        to every other test.
+        """
+        size, row, col = 32, 3, 7
+        image = np.full((size, size), 100, dtype=np.int16)
+        image[row, col] = 999
+        _write_fits_int16(tmp_path / "marker_00000.fits", image)
+
+        loaded = _stack(load_images(str(tmp_path)))[0]
+        assert loaded[row, col] == 999.0
+        assert loaded[col, row] == 100.0  # transpose guard
+        assert loaded[size - 1 - row, col] == 100.0  # vertical-flip guard
+        assert loaded[row, size - 1 - col] == 100.0  # horizontal-flip guard
+
+    def test_duplicated_runs_truncation(self, tmp_path):
+        """nbr_of_duplicated_runs=N keeps the first 1/N of the sorted list."""
+        for k in range(4):
+            _write_fits_int16(tmp_path / f"a_set1_{k:05d}.fits", np.full((16, 16), 1, dtype=np.int16))
+            _write_fits_int16(tmp_path / f"b_set2_{k:05d}.fits", np.full((16, 16), 2, dtype=np.int16))
+
+        loaded = _stack(load_images(str(tmp_path), nbr_of_duplicated_runs=2))
+        assert loaded.shape[0] == 4
+        np.testing.assert_array_equal(loaded, np.full((4, 16, 16), 1, dtype=np.float32))
+
+    @pytest.mark.parametrize("jupyter", [False, True])
+    def test_in_jupyter_both_paths(self, tmp_path, monkeypatch, jupyter):
+        """load_images consults in_jupyter() for its progress bar; both
+        branches must load identically (a loader rewrite could silently
+        drop the plumbing)."""
+        import neutronimaging.util
+
+        monkeypatch.setattr(neutronimaging.util, "in_jupyter", lambda: jupyter)
+        _write_fits_int16(tmp_path / "x_00000.fits", np.full((16, 16), 7, dtype=np.int16))
+
+        loaded = _stack(load_images(str(tmp_path)))
+        np.testing.assert_array_equal(loaded[0], np.full((16, 16), 7, dtype=np.float32))

--- a/tests/test_load_contract.py
+++ b/tests/test_load_contract.py
@@ -35,26 +35,33 @@ class TestShippedDataContract:
     """Pin the load contract on the full shipped 916-frame OB stack."""
 
     @pytest.fixture(scope="class")
-    def full_stack(self, data_dir):
-        return _stack(load_images(str(data_dir)))
+    def frames(self, data_dir):
+        """Per-frame view of the shipped stack.
 
-    def test_shape_and_dtype(self, full_stack):
-        assert full_stack.shape == (916, 512, 512)
-        assert full_stack.dtype == np.float32
+        Deliberately NOT stacked into one contiguous array: these
+        assertions only need per-frame access, and stacking would
+        duplicate ~1 GB alongside the loader's own copy in CI.
+        """
+        return load_images(str(data_dir)).data["sample"]["data"]
 
-    def test_sampled_pixel_goldens(self, full_stack):
+    def test_shape_and_dtype(self, frames):
+        assert len(frames) == 916
+        assert all(frame.shape == (512, 512) for frame in frames)
+        assert {frame.dtype for frame in frames} == {np.dtype(np.float32)}
+
+    def test_sampled_pixel_goldens(self, frames):
         """Spot values at off-center coordinates fail loudly on any spatial
         transform, unlike the mean-profile regressions."""
-        assert full_stack[100][37, 411] == 69.0
-        assert full_stack[100][250, 17] == 194.0
-        assert full_stack[500][37, 411] == 55.0
-        assert full_stack[500][250, 17] == 138.0
-        assert full_stack[915][37, 411] == 43.0
-        assert full_stack[915][250, 17] == 84.0
+        assert frames[100][37, 411] == 69.0
+        assert frames[100][250, 17] == 194.0
+        assert frames[500][37, 411] == 55.0
+        assert frames[500][250, 17] == 138.0
+        assert frames[915][37, 411] == 43.0
+        assert frames[915][250, 17] == 84.0
 
-    def test_frame0_total_counts(self, full_stack):
+    def test_frame0_total_counts(self, frames):
         """Frame 0's pixel sum equals the first Spectra counts entry."""
-        assert float(full_stack[0].sum()) == 162259.0
+        assert float(frames[0].sum()) == 162259.0
 
 
 class TestLoadSemantics:


### PR DESCRIPTION
## Summary

PR 1 of the NeuNorm-removal sequence for this repo (deep audit 2026-06-10; same playbook as CylindricalGeometryCorrection #56→#58). **Tests only — no production code changes.**

The existing npz regressions assert per-frame *means*, which can't detect a flipped/transposed/permuted image. This pins everything a loader replacement could silently break:

- **Load contract** (shipped 916-frame OB stack): shape `(916, 512, 512)`, float32, off-center sampled-pixel goldens, frame-0 total counts (= first Spectra entry, 162259)
- **Load semantics**: pixel parity vs independent astropy reads, sorted ordering + `*_SummedImg*` exclusion, orientation canary, duplicated-runs truncation, `in_jupyter()` both branches
- **Export/CLI contract** (new synthetic 3-window MCP dataset in tmp_path): per-source-stem float32 TIFF naming, **full-array** on-disk round-trip, verbatim sidecar copies, `--skipimg` count, skip-selector consistency — the export path previously had zero coverage
- **Two strict xfails documenting real bugs found while writing these** (fixes land in the follow-up PRs, where removing the markers is forced):
  1. `--skipimg` mislabels kept frames — NeuNorm's export zip-truncates 12 names against the skip-reduced stack
  2. `generate_config.py` is **broken end-to-end**: `json.dump` rejects numpy int64 in the `output=` path that the CLI always uses (the old smoke test never passed `output=`)

Suite: 5 → 20 tests (17 pass + 3 strict xfail), green against pinned NeuNorm 1.x.

Next: PR 2 swaps NeuNorm for direct astropy/tifffile I/O (with the auto-gamma-filter replicated per maintainer decision), gated by these tests + the npz regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)