### PR TITLE
fix: correctness batch from the 2026-06-10 audit (issues 1-2, 4-7, 9-10)

### DIFF
--- a/neutronimaging/detector_correction.py
+++ b/neutronimaging/detector_correction.py
@@ -9,6 +9,10 @@ import pandas as pd
 from astropy.io import fits
 from tqdm.auto import tqdm
 
+# smallest (1 - occupancy) the correction will divide by; below this the
+# denominator is numerically indistinguishable from the pole at occupancy 1
+_OCCUPANCY_EPS = float(np.finfo(np.float32).eps)
+
 
 def read_shutter_count(filename: str) -> pd.DataFrame:
     """Parse in shutter count data from csv"""
@@ -44,19 +48,49 @@ def merge_meta_data(
     shutter_time: pd.DataFrame,
     spectra: pd.DataFrame,
 ) -> pd.DataFrame:
-    """Consolidate meta data from three different dataframes into one"""
+    """Consolidate meta data from three different dataframes into one
+
+    Raises
+    ------
+    ValueError
+        If the ShutterCount and ShutterTimes files disagree on which
+        shutter windows exist (after their respective >0 filters), or if
+        any spectra row falls outside every shutter window — both cases
+        would otherwise flow downstream as NaN/negative-occupancy frames.
+    """
+    # the two sidecar files describe the same shutter windows; align them
+    # explicitly by shutter_index instead of positionally (a positional
+    # concat NaN-fills on length mismatch, and a window filtered from only
+    # one file silently shifts every row after it)
+    _df_shutter = pd.merge(shutter_count, shutter_time, on="shutter_index", how="outer", indicator=True)
+    if (_df_shutter["_merge"] != "both").any():
+        _bad = _df_shutter.loc[_df_shutter["_merge"] != "both", "shutter_index"].astype(int).tolist()
+        raise ValueError(
+            f"ShutterCount and ShutterTimes disagree: shutter window(s) {_bad} "
+            "exist in only one of the two files (after dropping zero-count / "
+            "zero-end-frame rows)"
+        )
+    _df_shutter = _df_shutter.drop(columns="_merge")
+
     _df = spectra.copy(deep=True)
-    _df_shutter = pd.concat([shutter_count, shutter_time], axis=1)
-    print(f"{_df_shutter =}")
     _df["run_num"] = spectra.index
     # initialize fields
     _df["shutter_index"] = -1
     _df["shutter_counts"] = -1
-    for _, row in _df_shutter.iterrows():
-        _idx, _cnt, _snr, _, _start, _end = row
-        _df.loc[_df["shutter_time"].between(_start, _end), "shutter_index"] = int(_idx)
-        _df.loc[_df["shutter_time"].between(_start, _end), "shutter_counts"] = int(_cnt)
-        _df.loc[_df["shutter_time"].between(_start, _end), "shutter_n_ratio"] = _snr
+    for row in _df_shutter.itertuples(index=False):
+        _in_window = _df["shutter_time"].between(row.start_frame, row.end_frame)
+        _df.loc[_in_window, "shutter_index"] = int(row.shutter_index)
+        _df.loc[_in_window, "shutter_counts"] = int(row.shutter_counts)
+        _df.loc[_in_window, "shutter_n_ratio"] = row.shutter_n_ratio
+
+    _unmatched = _df["shutter_index"] == -1
+    if _unmatched.any():
+        _first = _df.loc[_unmatched, "shutter_time"].iloc[0]
+        raise ValueError(
+            f"{int(_unmatched.sum())} spectra row(s) fall outside every shutter "
+            f"window (first offender: shutter_time={_first}); the occupancy "
+            "correction would silently produce NaN frames for them"
+        )
     return _df
 
 
@@ -219,7 +253,12 @@ def correct_images(
     _img = np.asarray(images)
     _pop = calc_pixel_occupancy_probability(images, metadata)
     _snr = metadata["shutter_n_ratio"].values[:, np.newaxis, np.newaxis]
-    _rst = _img / (1 - _pop) / _snr
+    # occupancy at or above 1 makes the (1 - pop) denominator vanish or go
+    # negative (the cumsum can exceed the shutter counts); mask those pixels
+    # to NaN instead of emitting inf or silently negative intensities
+    _denom = 1.0 - _pop
+    with np.errstate(divide="ignore", invalid="ignore"):
+        _rst = np.where(_denom > _OCCUPANCY_EPS, _img / _denom, np.nan) / _snr
     # NOTE: The very first and last image of each frame (shutter_index)
     #       needs specicial correction, therefore removing them from
     #       standard pipeline if specified

--- a/neutronimaging/preprocess.py
+++ b/neutronimaging/preprocess.py
@@ -11,6 +11,7 @@ This module contains necessary preprocessing toolkits for neutron imaging, inclu
 import warnings
 import json
 import itertools
+import numpy as np
 import pandas as pd
 from PIL import Image
 from datetime import datetime
@@ -164,7 +165,9 @@ def _generate_config_CG1D(
     lbs = ["aperture_HR", "aperture_HL", "aperture_VT", "aperture_VB"]
     lbs_binned = [f"{lb}_binned" for lb in lbs]
     for lb, lb_binned in zip(lbs, lbs_binned):
-        df.loc[:, lb_binned] = 0
+        # float init: binned values are aperture means, and an int64 0
+        # surviving into the config dict is not JSON serializable
+        df.loc[:, lb_binned] = 0.0
 
     # group by
     # - exposure_time
@@ -278,36 +281,45 @@ def _generate_config_CG1D(
                 )
 
             # generate time range
-            # NOTE: need confirmation from original developer
-            _tmp["time_range_s"] = {}
-            first_sample_time = (
-                _tmp["first_images"]["sample"]["time_stamp"]
-                if "time_stamp" in _tmp["first_images"]["sample"].keys()
-                else 0.0
-            )
-            first_ob_time = (
-                _tmp["first_images"]["ob"]["time_stamp"]
-                if "time_stamp" in _tmp["first_images"]["ob"].keys()
-                else 0.0
-            )
-            _tmp["time_range_s"]["before"] = max(first_sample_time - first_ob_time, 0)
-            last_sample_time = (
-                _tmp["last_images"]["sample"]["time_stamp"]
-                if "time_stamp" in _tmp["last_images"]["sample"].keys()
-                else 0.0
-            )
-            last_ob_time = (
-                _tmp["first_images"]["ob"]["time_stamp"]
-                if "time_stamp" in _tmp["first_images"]["ob"].keys()
-                else 0.0
-            )
-            _tmp["time_range_s"]["after"] = max(last_sample_time - last_ob_time, 0)
+            # before: how long the first sample image trails the first OB;
+            # after: how long the last OB trails the last sample image
+            # (reference implementation: python_notebooks_data_reduction,
+            # normalization_with_simplify_selection.py — previously 'after'
+            # read the FIRST ob and subtracted in the wrong order)
+            # a category missing sample or OB images has no defined range:
+            # report 0.0 (the previous 0.0-timestamp fallback leaked raw
+            # epoch seconds, ~1.6e9, into the config)
+            first_sample_time = _tmp["first_images"]["sample"].get("time_stamp")
+            first_ob_time = _tmp["first_images"]["ob"].get("time_stamp")
+            last_sample_time = _tmp["last_images"]["sample"].get("time_stamp")
+            last_ob_time = _tmp["last_images"]["ob"].get("time_stamp")
+            _tmp["time_range_s"] = {
+                "before": (
+                    max(first_sample_time - first_ob_time, 0)
+                    if first_sample_time is not None and first_ob_time is not None
+                    else 0.0
+                ),
+                "after": (
+                    max(last_ob_time - last_sample_time, 0)
+                    if last_sample_time is not None and last_ob_time is not None
+                    else 0.0
+                ),
+            }
 
     # dump dict to desired format if output file name provided
     if output is not None:
         _write_config_to_disk(cfg_dict, output, df)
 
     return cfg_dict, df
+
+
+def _json_default(value):
+    """Convert numpy scalars (pandas yields int64/float64) to JSON-native types"""
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.floating):
+        return float(value)
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
 
 
 def _write_config_to_disk(
@@ -318,7 +330,7 @@ def _write_config_to_disk(
     _file_extension = filename.split(".")[-1]
     if "json" in _file_extension.lower():
         with open(filename, "w") as outputf:
-            json.dump(cfg_dict, outputf, indent=2, sort_keys=True)
+            json.dump(cfg_dict, outputf, indent=2, sort_keys=True, default=_json_default)
     elif "csv" in _file_extension.lower():
         dataframe.to_csv(filename, sep="\t", index=False)
     else:
@@ -327,7 +339,7 @@ def _write_config_to_disk(
         )
         filename += ".json"
         with open(filename, "w") as outputf:
-            json.dump(cfg_dict, outputf, indent=2, sort_keys=True)
+            json.dump(cfg_dict, outputf, indent=2, sort_keys=True, default=_json_default)
 
 
 if __name__ == "__main__":

--- a/neutronimaging/util.py
+++ b/neutronimaging/util.py
@@ -16,7 +16,10 @@ def in_jupyter() -> bool:
 
         kernel_name = get_ipython().__class__.__name__
         state = True if "ZMQ" in kernel_name else False
-    except NameError:
+    except ImportError:
+        # no IPython installed at all (headless deployment); the previous
+        # `except NameError` never matched — a missing module raises
+        # ModuleNotFoundError, a subclass of ImportError
         state = False
     return state
 

--- a/scripts/mcp_detector_correction.py
+++ b/scripts/mcp_detector_correction.py
@@ -46,26 +46,33 @@ if __name__ == "__main__":
     skip_first_last_img = args["--skipimg"]
     verbose = args["--verbose"]
 
+    # validation
+    print("Validating input arguments")
+    if not Path(input_dir).is_dir():
+        raise FileNotFoundError(f"Input directory does not exist: {input_dir}")
+    if not Path(output_dir).is_dir():
+        raise FileNotFoundError(f"Output directory does not exist: {output_dir}")
+
     # in some rare instances, the MCP creates a duplicate set of the run in the same folder
     # we need to only consider the first set in the autoreduction
-    shutter_count_files = glob.glob(input_dir + "/*_ShutterCount.txt")
+    shutter_count_files = sorted(glob.glob(input_dir + "/*_ShutterCount.txt"))
+    if not shutter_count_files:
+        raise FileNotFoundError(f"No *_ShutterCount.txt file found in {input_dir}")
     nbr_of_duplicated_runs = len(shutter_count_files)
     if nbr_of_duplicated_runs > 1:
         print(f"The folder contains {nbr_of_duplicated_runs} sets of the same data!")
 
-    shutter_count_file = glob.glob(input_dir + "/*_ShutterCount.txt")[0]
-    shutter_time_file = glob.glob(input_dir + "/*_ShutterTimes.txt")[0]
-    spectra_file = glob.glob(input_dir + "/*_Spectra.txt")[0]
-    summed_file = glob.glob(input_dir + "/*_SummedImg.fits")[0]
-
-    # validation
-    print("Validating input arguments")
-    assert Path(input_dir).exists()
-    assert Path(output_dir).exists()
-    assert Path(shutter_count_file).exists()
-    assert Path(shutter_time_file).exists()
-    assert Path(spectra_file).exists()
-    assert Path(summed_file).exists()
+    # derive every sidecar file from one common prefix (the first set in
+    # sorted order); four independent unsorted globs could mix files from
+    # different duplicate sets
+    shutter_count_file = shutter_count_files[0]
+    _stem = Path(shutter_count_file).name[: -len("_ShutterCount.txt")]
+    shutter_time_file = os.path.join(input_dir, f"{_stem}_ShutterTimes.txt")
+    spectra_file = os.path.join(input_dir, f"{_stem}_Spectra.txt")
+    summed_file = os.path.join(input_dir, f"{_stem}_SummedImg.fits")
+    for _sidecar in (shutter_time_file, spectra_file, summed_file):
+        if not Path(_sidecar).exists():
+            raise FileNotFoundError(f"Expected sidecar file is missing: {_sidecar}")
 
     # process metadata
     print("Processing metadata")
@@ -80,6 +87,11 @@ if __name__ == "__main__":
     # load images
     print("Loading images into memory")
     images = load_images(input_dir, nbr_of_duplicated_runs)
+    if images.shape[0] != len(df_meta):
+        raise RuntimeError(
+            f"loaded {images.shape[0]} frames but the spectra metadata has "
+            f"{len(df_meta)} rows; the input directory is inconsistent"
+        )
 
     # perform image correction
     print("Perform correction")
@@ -123,11 +135,17 @@ if __name__ == "__main__":
     shutil.copyfile(summed_file, out_summed_file)
     # handle proper spectra parsing
     if skip_first_last_img:
+        # match the instrument-written format: headerless TSV with CRLF
+        # line endings, so read_spectra and the non-skip (verbatim copy)
+        # branch stay parseable the same way; pandas defaults previously
+        # wrote comma-separated WITH header under the same filename
         skipping_meta_data(df_meta).to_csv(
             out_spectra_file,
-            columns=['shutter_time', 'counts'],
+            columns=["shutter_time", "counts"],
             index=False,
-            index_label=False
+            header=False,
+            sep="\t",
+            lineterminator="\r\n",
         )
     else:
         shutil.copyfile(spectra_file, out_spectra_file)

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -207,17 +207,7 @@ class TestMcpDetectorCorrectionCli:
         np.testing.assert_array_equal(skipped, full[kept_run_nums])
 
 
-GENERATE_CONFIG_XFAIL = pytest.mark.xfail(
-    strict=True,
-    reason="generate_config_CG1D's output= path json.dumps numpy int64 scalars and "
-    "crashes (TypeError: Object of type int64 is not JSON serializable), so the CLI "
-    "is broken end-to-end on modern numpy/pandas; the existing test_preprocess smoke "
-    "never exercises output=. Fix lands in the correctness PR (remove this marker there).",
-)
-
-
 class TestGenerateConfigCli:
-    @GENERATE_CONFIG_XFAIL
     def test_single_image_dir(self, data_dir, tmp_path, script_path):
         out = tmp_path / "config.json"
         result = _run_cli(
@@ -231,7 +221,6 @@ class TestGenerateConfigCli:
         assert out.exists()
         json.loads(out.read_text())  # valid JSON
 
-    @GENERATE_CONFIG_XFAIL
     def test_comma_separated_image_dirs_and_tolerance(self, data_dir, tmp_path, script_path):
         out = tmp_path / "config.json"
         imgdirs = ",".join(

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -1,0 +1,252 @@
+"""Regression tests for the correctness batch (2026-06-10 audit issues
+1, 2, 4-7, 9, 10 + the generate_config int64 JSON fix).
+
+Each test pins a bug that previously corrupted output silently or crashed
+with a misleading error; see the audit for the full failure analyses.
+"""
+
+import subprocess
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from neutronimaging.detector_correction import (
+    correct_images,
+    merge_meta_data,
+    read_shutter_count,
+    read_shutter_time,
+    read_spectra,
+    skipping_meta_data,
+)
+
+
+def _run_cli(script, *args):
+    return subprocess.run(
+        [sys.executable, script, *map(str, args)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+def _read_fixture_meta(ds):
+    input_dir = ds["input_dir"]
+    return (
+        read_shutter_count(str(input_dir / f"{ds['prefix']}_ShutterCount.txt")),
+        read_shutter_time(str(input_dir / f"{ds['prefix']}_ShutterTimes.txt")),
+        read_spectra(str(input_dir / f"{ds['prefix']}_Spectra.txt")),
+    )
+
+
+class TestMergeMetaData:
+    def test_valid_data_merges_quietly(self, synthetic_mcp_dataset, capsys):
+        """audit #7: the debug print(f'{_df_shutter =}') polluted every call"""
+        counts, times, spectra = _read_fixture_meta(synthetic_mcp_dataset)
+        meta = merge_meta_data(counts, times, spectra)
+
+        assert capsys.readouterr().out == ""
+        assert (meta["shutter_index"] != -1).all()
+        assert meta["shutter_n_ratio"].notna().all()
+
+    def test_unmatched_spectra_row_raises(self, synthetic_mcp_dataset):
+        """audit #1: a spectra time outside every shutter window previously
+        kept shutter_counts=-1 / NaN ratio and flowed downstream as
+        fully-NaN or negative-occupancy frames, silently"""
+        counts, times, spectra = _read_fixture_meta(synthetic_mcp_dataset)
+        bad = pd.concat(
+            [spectra, pd.DataFrame({"shutter_time": [0.5], "counts": [123]})],
+            ignore_index=True,
+        )
+
+        with pytest.raises(ValueError, match="outside every shutter window"):
+            merge_meta_data(counts, times, bad)
+
+    def test_asymmetric_shutter_files_raise(self, synthetic_mcp_dataset):
+        """audit #7: a window filtered from only one sidecar file previously
+        misaligned the positional concat — cryptic int(NaN) ValueError one
+        way, silently shifted windows the other"""
+        ds = synthetic_mcp_dataset
+        counts, times, spectra = _read_fixture_meta(ds)
+
+        # drop window 1 from the counts side only
+        counts_missing = counts[counts["shutter_index"] != 1]
+        with pytest.raises(ValueError, match="ShutterCount and ShutterTimes disagree"):
+            merge_meta_data(counts_missing, times, spectra)
+
+        # and from the times side only
+        times_missing = times[times["shutter_index"] != 1]
+        with pytest.raises(ValueError, match="ShutterCount and ShutterTimes disagree"):
+            merge_meta_data(counts, times_missing, spectra)
+
+
+class TestOccupancyPoleGuard:
+    @pytest.mark.filterwarnings("error::RuntimeWarning")
+    def test_saturated_occupancy_masks_to_nan(self):
+        """audit #10: occupancy >= 1 previously emitted inf (pop == 1) or
+        silently NEGATIVE intensities (pop > 1, cumsum exceeding counts);
+        the filterwarnings marker also pins that the guarded division does
+        not leak RuntimeWarnings"""
+        # one shutter window, two frames of constant value 100 against
+        # shutter_counts 150: frame 0 has pop = 100/150 (fine), frame 1 has
+        # pop = 200/150 > 1 (pole crossed)
+        meta = pd.DataFrame(
+            {
+                "shutter_time": [0.1, 0.2],
+                "counts": [1, 1],
+                "run_num": [0, 1],
+                "shutter_index": [0, 0],
+                "shutter_counts": [150, 150],
+                "shutter_n_ratio": [1.0, 1.0],
+            }
+        )
+        images = np.full((2, 4, 4), 100.0, dtype=np.float32)
+
+        corrected = correct_images(images, meta)
+
+        assert np.isfinite(corrected[0]).all()
+        assert (corrected[0] > 0).all()
+        assert np.isnan(corrected[1]).all()
+
+
+class TestCliSpectraFormat:
+    def test_skipimg_spectra_round_trips_through_read_spectra(self, synthetic_mcp_dataset, script_path):
+        """audit #2: --skipimg previously rewrote *_Spectra.txt with pandas
+        defaults (comma-separated WITH header) while the non-skip branch
+        copies the headerless TSV original verbatim — read_spectra
+        mis-parsed the rewritten file into one un-split column"""
+        ds = synthetic_mcp_dataset
+        result = _run_cli(
+            script_path("mcp_detector_correction.py"), "--skipimg", ds["input_dir"], ds["output_dir"]
+        )
+        assert result.returncode == 0, result.stderr
+
+        out_spectra = ds["output_dir"] / f"{ds['prefix']}_Spectra.txt"
+        parsed = read_spectra(str(out_spectra))
+
+        n_kept = ds["n_groups"] * (ds["frames_per_group"] - 2)
+        assert parsed.shape == (n_kept, 2)
+        assert parsed.notna().all().all()
+
+        counts, times, spectra = _read_fixture_meta(ds)
+        expected = skipping_meta_data(merge_meta_data(counts, times, spectra))
+        np.testing.assert_allclose(parsed["shutter_time"].values, expected["shutter_time"].values)
+        np.testing.assert_allclose(parsed["counts"].values, expected["counts"].values)
+
+        # byte-level format contract: headerless TSV with CRLF, like the
+        # instrument-written original
+        raw = out_spectra.read_bytes()
+        assert b"\t" in raw and b"\r\n" in raw
+        assert b"," not in raw and b"shutter_time" not in raw
+
+
+class TestCliInputResolution:
+    def test_duplicate_sets_resolve_to_first_sorted_prefix(self, synthetic_mcp_dataset, script_path):
+        """audit #6: four independent unsorted globs could mix sidecar files
+        from different duplicate sets; everything must derive from the
+        first set in sorted order"""
+        ds = synthetic_mcp_dataset
+        input_dir = ds["input_dir"]
+
+        # fabricate a complete second set whose prefix sorts AFTER the
+        # primary; its frames carry different values so a mixed selection
+        # would change the exported data
+        dup_prefix = "ZZ_synth_999"
+        for name in (
+            "_ShutterCount.txt",
+            "_ShutterTimes.txt",
+            "_Spectra.txt",
+            "_SummedImg.fits",
+        ):
+            src = input_dir / f"{ds['prefix']}{name}"
+            (input_dir / f"{dup_prefix}{name}").write_bytes(src.read_bytes())
+        from astropy.io import fits
+
+        for k in range(ds["n_frames"]):
+            hdu = fits.PrimaryHDU(np.full(ds["shape"], 999, dtype=">i2"))
+            fits.HDUList([hdu]).writeto(str(input_dir / f"{dup_prefix}_{k:05d}.fits"))
+
+        result = _run_cli(script_path("mcp_detector_correction.py"), input_dir, ds["output_dir"])
+        assert result.returncode == 0, result.stderr
+        assert "2 sets" in result.stdout
+
+        exported = sorted(p.name for p in ds["output_dir"].glob("*.tif"))
+        expected = sorted(f"{ds['prefix']}_{k:05d}.tif" for k in range(ds["n_frames"]))
+        assert exported == expected, "exported frames must all come from the first sorted set"
+
+    def test_missing_sidecar_fails_descriptively(self, synthetic_mcp_dataset, script_path):
+        """audit #6: a missing sidecar previously died with a bare IndexError
+        from glob(...)[0] before any validation ran"""
+        ds = synthetic_mcp_dataset
+        (ds["input_dir"] / f"{ds['prefix']}_ShutterTimes.txt").unlink()
+
+        result = _run_cli(script_path("mcp_detector_correction.py"), ds["input_dir"], ds["output_dir"])
+        assert result.returncode != 0
+        assert "Expected sidecar file is missing" in result.stderr
+        assert "IndexError" not in result.stderr
+
+    def test_empty_input_dir_fails_descriptively(self, tmp_path, script_path):
+        empty_in = tmp_path / "empty_in"
+        out = tmp_path / "out"
+        empty_in.mkdir()
+        out.mkdir()
+
+        result = _run_cli(script_path("mcp_detector_correction.py"), empty_in, out)
+        assert result.returncode != 0
+        assert "No *_ShutterCount.txt" in result.stderr
+
+
+class TestTimeRange:
+    @pytest.fixture(scope="class")
+    def config(self, data_dir):
+        from neutronimaging.preprocess import generate_config_CG1D
+
+        return generate_config_CG1D(
+            str(data_dir / "IPTS-20267/raw/radiographs"),
+            str(data_dir / "IPTS-20267/raw/ob"),
+            str(data_dir / "IPTS-20267/raw/df"),
+        )
+
+    def test_no_epoch_timestamps_leak(self, config):
+        """audit #5: a category with sample but no OB previously reported
+        time_range_s ~ 1.58e9 s (the raw epoch timestamp, ~50 years) —
+        shipped in the committed example notebook"""
+        for configs in config.values():
+            for cfg in configs.values():
+                for side, value in cfg["time_range_s"].items():
+                    assert 0 <= value < 1e8, f"{side} leaked an epoch timestamp: {value}"
+
+    def test_time_range_consistent_with_first_last_images(self, config):
+        """audit #4: 'after' previously read the FIRST ob timestamp (copy-
+        paste from the 'before' block) and subtracted in the wrong order;
+        the reference implementation computes max(last_ob - last_sample, 0)"""
+        checked_after = 0
+        for configs in config.values():
+            for cfg in configs.values():
+                first, last = cfg["first_images"], cfg["last_images"]
+                tr = cfg["time_range_s"]
+                if first["sample"] and first["ob"]:
+                    expected = max(first["sample"]["time_stamp"] - first["ob"]["time_stamp"], 0)
+                    assert tr["before"] == expected
+                else:
+                    assert tr["before"] == 0.0
+                if last["sample"] and last["ob"]:
+                    expected = max(last["ob"]["time_stamp"] - last["sample"]["time_stamp"], 0)
+                    assert tr["after"] == expected
+                    checked_after += 1
+                else:
+                    assert tr["after"] == 0.0
+        assert checked_after > 0, "shipped data must exercise the both-sides-present path"
+
+
+class TestInJupyter:
+    def test_headless_without_ipython_returns_false(self, monkeypatch):
+        """audit #9: without IPython installed, in_jupyter() previously
+        escaped its `except NameError` with a ModuleNotFoundError and
+        crashed the caller"""
+        monkeypatch.setitem(sys.modules, "IPython", None)
+
+        from neutronimaging.util import in_jupyter
+
+        assert in_jupyter() is False


### PR DESCRIPTION
## Summary

NIS PR 3 of the audit-driven series (`audits/NeutronImagingScripts_audit_2026-06-10.md`): the correctness batch, each fix with a regression test.

| Issue | Fix |
|----|-----|
| #1 (High) | Spectra rows outside every shutter window now **raise** in `merge_meta_data` — previously they kept `shutter_counts=-1`/NaN ratio and produced fully-NaN or negative-occupancy frames with no warning |
| #2 (High) | `--skipimg` writes `*_Spectra.txt` as **headerless TSV with CRLF** (the instrument format; `read_spectra` round-trips it) — previously pandas defaults wrote comma-separated WITH header under the same filename the non-skip branch copies verbatim |
| #4 (Med) | `time_range_s["after"]` read the **first** OB timestamp (copy-paste of the 'before' block) and subtracted in the wrong order; now `max(last_ob − last_sample, 0)` per the reference implementation in python_notebooks_data_reduction |
| #5 (Med) | Categories missing sample or OB images report `0.0` instead of leaking raw epoch seconds (~1.58e9, reproduced on shipped IPTS-20267 data) into the config |
| #6 (Med) | CLI derives all four sidecar files from one common prefix (first sorted ShutterCount) instead of four independent unsorted globs that could mix duplicate sets; real validation with descriptive `FileNotFoundError`s replaces the post-hoc tautological asserts; loaded frame count is cross-checked against spectra rows |
| #7 (Med) | `merge_meta_data` uses an explicit **outer merge on `shutter_index`** with a symmetry check raising a descriptive error (both directions tested); named-tuple access replaces positional unpacking; debug `print` removed |
| #9 (Med) | `in_jupyter()` catches `ImportError` — `except NameError` never matched a missing IPython module |
| #10 (Low) | Occupancy pole guard in `correct_images`: occupancy ≥ 1 masks to NaN under `np.errstate` (mirroring iBeatles' guard) instead of inf at the pole or **silently negative intensities** beyond it |
| int64 JSON | `generate_config` output works end-to-end: float-typed binned aperture columns + numpy-safe `json.dump` default. The two strict-xfail CLI tests from #18 now pass and their markers are removed. |

## Test plan

- New `tests/test_correctness.py`: 11 regression tests (merge symmetry both directions, unmatched-row raise, no-debug-print, pole guard incl. RuntimeWarning pinning, spectra byte-level round-trip, duplicate-set prefix resolution, missing-sidecar/empty-dir CLI errors, time_range consistency + epoch-leak guards on shipped data, headless in_jupyter)
- Clean venv (no NeuNorm, no optional packages): **39 passed** (was 26 passed + 2 xfail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)