### PR TITLE
fix(packaging): exclude data/tests/example/pixi.lock from the sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,11 @@ build-file = "neutronimaging/_version.py"
 [tool.hatch.build]
 artifacts = ["neutronimaging/_version.py"]
 
+[tool.hatch.build.targets.sdist]
+# keep the sdist installable-sized: data/ is ~571 MB (PyPI caps files at
+# 100 MB) and tests/ cannot run without it; both stay git-only
+exclude = ["data", "tests", "example", "pixi.lock"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["neutronimaging"]
 


### PR DESCRIPTION
## What

Adds a `[tool.hatch.build.targets.sdist]` exclude list: `data`, `tests`, `example`, `pixi.lock`.

## Why

Building v1.6 produced a **306 MB sdist** — hatchling includes all git-tracked files by default, which pulled in the ~571 MB `data/` tree. PyPI rejects files over 100 MB, so the release upload would fail. `tests/` is excluded with it because the suite cannot run without `data/`; `example/` and the lockfile aren't installation material either. The wheel target was already package-only (18 KB) and is unaffected.

Verified: rebuilt sdist is **23 KB** containing the package, the `scripts/` autoreduce wrappers, README/LICENSE/pyproject.

## Release-flow note (flagging explicitly)

The `v1.6` tag was created minutes ago and points at the pre-fix commit. After this merges I will **re-point `v1.6`** to the merged head so the release carries this fix. That's safe *here* because nothing has consumed the tag — no tag-triggered automation exists in this repo (by decision) and nothing was uploaded to PyPI yet. This is not the CGC situation (where the tag had already been consumed by a workflow snapshot and a PyPI upload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)