### PR TITLE
ci: add PyPI trusted-publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+name: Publish to PyPI
+
+# Release flow: tag on main (vX.Y[.Z]) -> build sdist+wheel -> trusted-publish.
+# Versioningit derives the version from the tag, so a clean v1.6 tag yields a
+# clean 1.6 release (untagged commits build dev versions and are NOT published
+# here because only tag pushes trigger this workflow).
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # versioningit needs the full history and tags to compute the version
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        # build isolation pulls hatchling + versioningit from
+        # [build-system].requires; no pixi needed for a pure build
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # Trusted publisher is bound to this environment name on PyPI; configure a
+    # protection rule on the `pypi` environment in repo settings to gate it.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/NeutronImaging
+    permissions:
+      id-token: write # OIDC token for PyPI trusted publishing
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,13 @@ Pixi-managed — run everything through `pixi run`.
 - versioningit from git tags; `neutronimaging/_version.py` is generated and
   gitignored. Dev versions read `1.5.0.dev*` because tag v1.5 is not an
   ancestor of main — the explicit v1.6 release tag supersedes this.
-- No publish automation by decision (no known downstream pip consumers);
-  release = tag on main → `python -m build` + twine.
+- Release = tag on main (`v*`). A push of a `v*` tag triggers
+  `.github/workflows/publish.yml`, which builds the sdist+wheel and uploads to
+  PyPI via OIDC trusted publishing (no API token). The publish job runs in the
+  `pypi` GitHub environment; the trusted publisher on PyPI is bound to owner
+  `ornlneutronimaging`, repo `NeutronImagingScripts`, workflow `publish.yml`,
+  environment `pypi`. (Supersedes the earlier "no publish automation" decision,
+  2026-06-16.) Untagged commits build dev versions and are not published.
 - License is MIT (team decision 2026-06-12, NDP standard) — this settled the
   historical GPLv3-file / BSD-setup.py / LGPLv2-classifier contradiction.
 


### PR DESCRIPTION
## What

Adds `.github/workflows/publish.yml` — automated PyPI publishing via GitHub Actions OIDC **trusted publishing** (no stored API token).

- **Trigger:** push of a `v*` tag (matches the existing "release = tag on main" flow). Untagged commits build dev versions and are never published.
- **`build` job:** checks out full history + tags (versioningit needs them to derive the version), builds sdist+wheel with `python -m build` in isolation — hatchling + versioningit come from `[build-system].requires`, so no pixi is needed for the build. Runs with only `contents: read`.
- **`publish` job:** downloads the artifact and uploads via `pypa/gh-action-pypi-publish`. This is the only job with `id-token: write`, and it runs in the `pypi` GitHub environment.

## Pinning

- `pypa/gh-action-pypi-publish` pinned to SHA `cef221092ed1bacb1cc03d23a2d87d1d172e277b` (v1.14.0).
- First-party `actions/*` left on version tags, consistent with `test.yaml`.

## PyPI / repo configuration (already done out-of-band)

Trusted publisher on PyPI (`neutronimaging` project) is bound to:

| Field | Value |
|---|---|
| Owner | `ornlneutronimaging` |
| Repository name | `NeutronImagingScripts` |
| Workflow name | `publish.yml` |
| Environment name | `pypi` |

## Docs

Updates the `CLAUDE.md` "Versioning and release" section to document the automated flow, superseding the earlier "no publish automation by decision" note.

## Note

This reverses a prior team decision (no publish automation). Once merged to `main`, the first `v*` tag push will publish to PyPI.